### PR TITLE
Avoid build errors for aarch64

### DIFF
--- a/boost/spirit/home/support/char_encoding/standard_wide.hpp
+++ b/boost/spirit/home/support/char_encoding/standard_wide.hpp
@@ -83,7 +83,7 @@ namespace boost { namespace spirit { namespace char_encoding
         strict_ischar(int ch)
         {
             // ch should be representable as a wchar_t
-            return ch >= WCHAR_MIN && ch <= WCHAR_MAX;
+            return ch >= int(WCHAR_MIN) && ch <= int(WCHAR_MAX);
         }
 
         static bool

--- a/boost/spirit/home/support/char_encoding/standard_wide.hpp
+++ b/boost/spirit/home/support/char_encoding/standard_wide.hpp
@@ -83,7 +83,11 @@ namespace boost { namespace spirit { namespace char_encoding
         strict_ischar(int ch)
         {
             // ch should be representable as a wchar_t
-            return ch >= int(WCHAR_MIN) && ch <= int(WCHAR_MAX);
+            #if WCHAR_MIN==0
+            return ch >= 0;
+            #else
+            return true;
+            #endif
         }
 
         static bool


### PR DESCRIPTION
We see build errors [a] for aarch64 . For aarch64 ( Linux techlab-arm64-thunderx-02 4.14.0-115.6.1.el7a.aarch64 )  `WCHAR_MIN` is `0U` and  `WCHAR_MAX` is `0xffffffffU` i.e. `unsigned int` while for amd64  (Linux cmsdev31.cern.ch 3.10.0-957.21.3.el7.x86_64)  `WCHAR_MIN` is `(-2147483647 - 1)` and  `WCHAR_MAX` is `(2147483647)` i.e. 'int`. 

Here we propose to to convert WCHAR_MIN AND WCHAR_MAX to int to avoid type comparison errors.

[a]
```
boost/spirit/home/support/char_encoding/standard_wide.hpp: In static member function 'static bool boost::spirit::char_encoding::standard_wide::strict_ischar(int)':
boost/1.72.0/include/boost/spirit/home/support/char_encoding/standard_wide.hpp:86:23: error: comparison of unsigned expression >= 0 is always true [-Werror=type-limits]
             return ch >= WCHAR_MIN && ch <= WCHAR_MAX;
                       ^
boost/spirit/home/support/char_encoding/standard_wide.hpp:86:23: error: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Werror=sign-compare]
boost/spirit/home/support/char_encoding/standard_wide.hpp:86:42: error: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Werror=sign-compare]
             return ch >= WCHAR_MIN && ch <= WCHAR_MAX;
```