### PR TITLE
Better annotate interprocess_exception

### DIFF
--- a/boost/interprocess/detail/shared_dir_helpers.hpp
+++ b/boost/interprocess/detail/shared_dir_helpers.hpp
@@ -68,7 +68,7 @@ struct shared_dir_constants<wchar_t>
             //Throw if bootstamp not available
             if(!winapi::get_last_bootup_time(stamp)){
                error_info err = system_error_code();
-               throw interprocess_exception(err);
+               throw interprocess_exception(err, "windows_bootstamp: winapi::get_last_bootup_time failed");
             }
          }
          //Use std::string. Even if this will be constructed in shared memory, all
@@ -139,7 +139,7 @@ inline void get_shared_dir_root(std::basic_string<CharT> &dir_path)
    //We always need this path, so throw on error
    if(dir_path.empty()){
       error_info err = system_error_code();
-      throw interprocess_exception(err);
+      throw interprocess_exception(err, "get_shared_dir_root: empty dir_path");
    }
 
    dir_path += shared_dir_constants<CharT>::dir_interprocess();
@@ -211,7 +211,7 @@ inline void create_shared_dir_and_clean_old(std::basic_string<CharT> &shared_dir
       //If fails, check that it's because already exists
       if(!open_or_create_shared_directory(root_shared_dir.c_str())){
          error_info info(system_error_code());
-         throw interprocess_exception(info);
+         throw interprocess_exception(info, "create_shared_dir_and_clean_old: open_or_create_shared_directory failed");
       }
 
       #if defined(BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME)
@@ -220,7 +220,7 @@ inline void create_shared_dir_and_clean_old(std::basic_string<CharT> &shared_dir
          //If fails, check that it's because already exists
          if(!open_or_create_shared_directory(shared_dir.c_str())){
             error_info info(system_error_code());
-            throw interprocess_exception(info);
+            throw interprocess_exception(info, "open_or_create_shared_directory: open_or_create_shared_directory");
          }
          //Now erase all old directories created in the previous boot sessions
          std::basic_string<CharT> subdir = shared_dir;

--- a/boost/interprocess/exceptions.hpp
+++ b/boost/interprocess/exceptions.hpp
@@ -43,7 +43,7 @@ class BOOST_SYMBOL_VISIBLE interprocess_exception : public std::exception
       BOOST_CATCH(...) {} BOOST_CATCH_END
    }
 
-   interprocess_exception(const error_info &err_info, const char *str = 0)
+  interprocess_exception(const error_info &err_info, const char *str /*= 0*/)
       :  m_err(err_info)
    {
       BOOST_TRY{
@@ -83,7 +83,7 @@ class BOOST_SYMBOL_VISIBLE lock_exception : public interprocess_exception
 {
    public:
    lock_exception(error_code_t err = lock_error) BOOST_NOEXCEPT
-      :  interprocess_exception(err)
+     :  interprocess_exception(err, "lock_exception")
    {}
 
    const char* what() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE

--- a/boost/interprocess/segment_manager.hpp
+++ b/boost/interprocess/segment_manager.hpp
@@ -1128,7 +1128,7 @@ class segment_manager
             return it->get_block_header()->value();
          }
          if(dothrow){
-            throw interprocess_exception(already_exists_error);
+           throw interprocess_exception(already_exists_error,"priv_generic_named_construct: dowthrow == true");
          }
          else{
             return 0;

--- a/boost/interprocess/shared_memory_object.hpp
+++ b/boost/interprocess/shared_memory_object.hpp
@@ -234,7 +234,7 @@ inline bool shared_memory_object::priv_open_or_create
    //Set accesses
    if (mode != read_write && mode != read_only){
       error_info err = other_error;
-      throw interprocess_exception(err);
+      throw interprocess_exception(err, "shared_memory_object::priv_open_or_create shared dir failure");
    }
 
    switch(type){
@@ -250,7 +250,7 @@ inline bool shared_memory_object::priv_open_or_create
       default:
          {
             error_info err = other_error;
-            throw interprocess_exception(err);
+            throw interprocess_exception(err, "shared_memory_object::priv_open_or_create unknown type");
          }
    }
 
@@ -258,7 +258,7 @@ inline bool shared_memory_object::priv_open_or_create
    if(m_handle == ipcdetail::invalid_file()){
       error_info err = system_error_code();
       this->priv_close();
-      throw interprocess_exception(err);
+      throw interprocess_exception(err, "shared_memory_object::priv_open_or_create invalid_file");
    }
 
    m_mode = mode;
@@ -299,7 +299,7 @@ inline void shared_memory_object::truncate(offset_t length)
 {
    if(!ipcdetail::truncate_file(m_handle, (std::size_t)length)){
       error_info err = system_error_code();
-      throw interprocess_exception(err);
+      throw interprocess_exception(err, "shared_memory_object::truncate");
    }
 }
 
@@ -366,7 +366,7 @@ inline bool shared_memory_object::priv_open_or_create
    }
    else{
       error_info err(mode_error);
-      throw interprocess_exception(err);
+      throw interprocess_exception(err, "shared_memory_object::priv_open_or_create unknown mode");
    }
    ::mode_t unix_perm = perm.get_permissions();
 
@@ -414,7 +414,7 @@ inline bool shared_memory_object::priv_open_or_create
       default:
       {
          error_info err = other_error;
-         throw interprocess_exception(err);
+         throw interprocess_exception(err, "shared_memory_object::priv_open_or_create type unknown");
       }
    }
 
@@ -422,7 +422,7 @@ inline bool shared_memory_object::priv_open_or_create
    if(m_handle < 0){
       error_info err = errno;
       this->priv_close();
-      throw interprocess_exception(err);
+      throw interprocess_exception(err, "shared_memory_object::priv_open_or_create shm_open failed");
    }
 
    m_filename = filename;
@@ -464,7 +464,7 @@ inline void shared_memory_object::truncate(offset_t length)
 
    if (ret && ret != EOPNOTSUPP && ret != ENODEV){
       error_info err(ret);
-      throw interprocess_exception(err);
+      throw interprocess_exception(err, "shared_memory_object::truncate posix failure");
    }
    //ftruncate fallback
    #endif //BOOST_INTERPROCESS_POSIX_FALLOCATE
@@ -474,7 +474,7 @@ inline void shared_memory_object::truncate(offset_t length)
       if (errno == EINTR)
          goto handle_eintr;
       error_info err(system_error_code());
-      throw interprocess_exception(err);
+      throw interprocess_exception(err, "shared_memory_object::truncate failure");
    }
 }
 

--- a/boost/interprocess/sync/posix/condition.hpp
+++ b/boost/interprocess/sync/posix/condition.hpp
@@ -158,12 +158,12 @@ inline posix_condition::posix_condition()
    res = pthread_condattr_setpshared(&cond_attr, PTHREAD_PROCESS_SHARED);
    if(res != 0){
       pthread_condattr_destroy(&cond_attr);
-      throw interprocess_exception(res);
+      throw interprocess_exception(res,"posix_condition::ctr pthread_condattr_setpshared failed");
    }
    res = pthread_cond_init(&m_condition, &cond_attr);
    pthread_condattr_destroy(&cond_attr);
    if(res != 0){
-      throw interprocess_exception(res);
+     throw interprocess_exception(res, "posix_condition::ctr pthread_cond_init failed");
    }
 }
 

--- a/boost/interprocess/sync/posix/semaphore_wrapper.hpp
+++ b/boost/interprocess/sync/posix/semaphore_wrapper.hpp
@@ -100,13 +100,13 @@ inline bool semaphore_open
       default:
       {
          error_info err(other_error);
-         throw interprocess_exception(err);
+         throw interprocess_exception(err, "semaphore_open: unknown type");
       }
    }
 
    //Check for error
    if(handle == BOOST_INTERPROCESS_POSIX_SEM_FAILED){
-      throw interprocess_exception(error_info(errno));
+     throw interprocess_exception(error_info(errno),"semaphore_open: sem_open failed");
    }
 
    return true;
@@ -148,7 +148,7 @@ inline void semaphore_init(sem_t *handle, unsigned int initialCount)
    //In the future, a successful call might be required to return 0.
    if(ret == -1){
       error_info err = system_error_code();
-      throw interprocess_exception(err);
+      throw interprocess_exception(err, "semaphore_init: sem_init failed");
    }
 }
 
@@ -167,7 +167,7 @@ inline void semaphore_post(sem_t *handle)
    int ret = sem_post(handle);
    if(ret != 0){
       error_info err = system_error_code();
-      throw interprocess_exception(err);
+      throw interprocess_exception(err, "semaphore_post: sem_post failed");
    }
 }
 
@@ -176,7 +176,7 @@ inline void semaphore_wait(sem_t *handle)
    int ret = sem_wait(handle);
    if(ret != 0){
       error_info err = system_error_code();
-      throw interprocess_exception(err);
+      throw interprocess_exception(err, "semaphore_wait: sem_wait failed");
    }
 }
 
@@ -189,7 +189,7 @@ inline bool semaphore_try_wait(sem_t *handle)
       return false;
    }
    error_info err = system_error_code();
-   throw interprocess_exception(err);
+   throw interprocess_exception(err, "semaphore_try_wait: sem_trywait failed");
 }
 
 #ifndef BOOST_INTERPROCESS_POSIX_TIMEOUTS
@@ -235,7 +235,7 @@ inline bool semaphore_timed_wait(sem_t *handle, const TimePoint &abs_time)
          return false;
       }
       error_info err = system_error_code();
-      throw interprocess_exception(err);
+      throw interprocess_exception(err, "semaphore_timed_wait: sem_timedwait failed");
    }
    return false;
    #else //#ifdef BOOST_INTERPROCESS_POSIX_TIMEOUTS


### PR DESCRIPTION
The IBs with the external generator process are periodically failing with the unhelpful error message
```
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
	26077_0 process: caught exception 
	boost::interprocess_exception::library_error 15-Dec-2022 03:59:39 CET
	  while serialize lumi
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
```

That message happens when `boost::interprocess_exception` constructor is passed an error_info that is set to 0 AND the constructor is not passed a `const char*`. I went and modified all the places our code might reach a function that calls `boost::interprocess_exception` and forces it to also pass a `const char*` saying why the exception is being thrown. 

Hopefully this will help track down the problems we see ever so often.
