### PR TITLE
Change mpl::integral_c to boost::integral_constant to avoid Clang 16 …

### DIFF
--- a/boost/numeric/conversion/detail/int_float_mixture.hpp
+++ b/boost/numeric/conversion/detail/int_float_mixture.hpp
@@ -16,15 +16,15 @@
 #include "boost/numeric/conversion/int_float_mixture_enum.hpp"
 #include "boost/numeric/conversion/detail/meta.hpp"
 
-#include "boost/mpl/integral_c.hpp"
+#include "boost/type_traits/integral_constant.hpp"
 
 namespace boost { namespace numeric { namespace convdetail
 {
   // Integral Constants for 'IntFloatMixture'
-  typedef mpl::integral_c<int_float_mixture_enum, integral_to_integral> int2int_c ;
-  typedef mpl::integral_c<int_float_mixture_enum, integral_to_float>    int2float_c ;
-  typedef mpl::integral_c<int_float_mixture_enum, float_to_integral>    float2int_c ;
-  typedef mpl::integral_c<int_float_mixture_enum, float_to_float>       float2float_c ;
+  typedef boost::integral_constant<int_float_mixture_enum, integral_to_integral> int2int_c ;
+  typedef boost::integral_constant<int_float_mixture_enum, integral_to_float>    int2float_c ;
+  typedef boost::integral_constant<int_float_mixture_enum, float_to_integral>    float2int_c ;
+  typedef boost::integral_constant<int_float_mixture_enum, float_to_float>       float2float_c ;
 
   // Metafunction:
   //

--- a/boost/numeric/conversion/detail/sign_mixture.hpp
+++ b/boost/numeric/conversion/detail/sign_mixture.hpp
@@ -16,15 +16,15 @@
 #include "boost/numeric/conversion/sign_mixture_enum.hpp"
 #include "boost/numeric/conversion/detail/meta.hpp"
 
-#include "boost/mpl/integral_c.hpp"
+#include "boost/type_traits/integral_constant.hpp"
 
 namespace boost { namespace numeric { namespace convdetail
 {
   // Integral Constants for 'SignMixture'
-  typedef mpl::integral_c<sign_mixture_enum, unsigned_to_unsigned> unsig2unsig_c ;
-  typedef mpl::integral_c<sign_mixture_enum, signed_to_signed>     sig2sig_c ;
-  typedef mpl::integral_c<sign_mixture_enum, signed_to_unsigned>   sig2unsig_c ;
-  typedef mpl::integral_c<sign_mixture_enum, unsigned_to_signed>   unsig2sig_c ;
+  typedef boost::integral_constant<sign_mixture_enum, unsigned_to_unsigned> unsig2unsig_c ;
+  typedef boost::integral_constant<sign_mixture_enum, signed_to_signed>     sig2sig_c ;
+  typedef boost::integral_constant<sign_mixture_enum, signed_to_unsigned>   sig2unsig_c ;
+  typedef boost::integral_constant<sign_mixture_enum, unsigned_to_signed>   unsig2sig_c ;
 
   // Metafunction:
   //

--- a/boost/numeric/conversion/detail/udt_builtin_mixture.hpp
+++ b/boost/numeric/conversion/detail/udt_builtin_mixture.hpp
@@ -15,15 +15,15 @@
 #include "boost/numeric/conversion/udt_builtin_mixture_enum.hpp"
 #include "boost/numeric/conversion/detail/meta.hpp"
 
-#include "boost/mpl/integral_c.hpp"
+#include "boost/type_traits/integral_constant.hpp"
 
 namespace boost { namespace numeric { namespace convdetail
 {
   // Integral Constants for 'UdtMixture'
-  typedef mpl::integral_c<udt_builtin_mixture_enum, builtin_to_builtin> builtin2builtin_c ;
-  typedef mpl::integral_c<udt_builtin_mixture_enum, builtin_to_udt>     builtin2udt_c ;
-  typedef mpl::integral_c<udt_builtin_mixture_enum, udt_to_builtin>     udt2builtin_c ;
-  typedef mpl::integral_c<udt_builtin_mixture_enum, udt_to_udt>         udt2udt_c ;
+  typedef boost::integral_constant<udt_builtin_mixture_enum, builtin_to_builtin> builtin2builtin_c ;
+  typedef boost::integral_constant<udt_builtin_mixture_enum, builtin_to_udt>     builtin2udt_c ;
+  typedef boost::integral_constant<udt_builtin_mixture_enum, udt_to_builtin>     udt2builtin_c ;
+  typedef boost::integral_constant<udt_builtin_mixture_enum, udt_to_udt>         udt2udt_c ;
 
   // Metafunction:
   //


### PR DESCRIPTION
…errors when constructing out of range enums

patch from https://github.com/boostorg/numeric_conversion/commit/50a1eae942effb0a9b90724323ef8f2a67e7984a