### PR TITLE
GCC14: make base_type public for classes with conversion operator

### DIFF
--- a/boost/archive/basic_archive.hpp
+++ b/boost/archive/basic_archive.hpp
@@ -40,8 +40,9 @@ BOOST_ARCHIVE_VERSION();
 typedef boost::serialization::library_version_type library_version_type;
 
 class version_type {
-private:
+public:
     typedef uint_least32_t base_type;
+private:
     base_type t;
 public:
     // should be private - but MPI fails if it's not!!!
@@ -73,8 +74,9 @@ public:
 };
 
 class class_id_type {
-private:
+public:
     typedef int_least16_t base_type;
+private:
     base_type t;
 public:
     // should be private - but then can't use BOOST_STRONG_TYPE below
@@ -112,8 +114,9 @@ public:
 #define BOOST_SERIALIZATION_NULL_POINTER_TAG boost::archive::class_id_type(-1)
 
 class object_id_type {
-private:
+public:
     typedef uint_least32_t base_type;
+private:
     base_type t;
 public:
     object_id_type(): t(0) {}
@@ -152,6 +155,7 @@ public:
 #endif
 
 struct tracking_type {
+    typedef bool base_type;
     bool t;
     explicit tracking_type(const bool t_ = false)
         : t(t_)

--- a/boost/mpl/assert.hpp
+++ b/boost/mpl/assert.hpp
@@ -184,8 +184,7 @@ template< typename P > struct assert_arg_pred_not
     typedef typename assert_arg_pred_impl<p>::type type;
 };
 
-#if BOOST_WORKAROUND(BOOST_GCC_VERSION, >= 80000)
-#define BOOST_MPL_IGNORE_PARENTHESES_WARNING
+#ifdef BOOST_MPL_IGNORE_PARENTHESES_WARNING
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wparentheses"
 #endif

--- a/boost/serialization/collection_size_type.hpp
+++ b/boost/serialization/collection_size_type.hpp
@@ -18,8 +18,9 @@ namespace serialization {
 //BOOST_STRONG_TYPEDEF(std::size_t, collection_size_type)
 
 class collection_size_type {
-private:
+public:
     typedef std::size_t base_type;
+private:
     base_type t;
 public:
     collection_size_type(): t(0) {}

--- a/boost/serialization/item_version_type.hpp
+++ b/boost/serialization/item_version_type.hpp
@@ -23,8 +23,9 @@ namespace serialization {
 #endif
 
 class item_version_type {
-private:
+public:
     typedef unsigned int base_type;
+private:
     base_type t;
 public:
     // should be private - but MPI fails if it's not!!!

--- a/boost/serialization/library_version_type.hpp
+++ b/boost/serialization/library_version_type.hpp
@@ -34,8 +34,9 @@ namespace serialization {
  * binary archives won't be readable !!!
  */
 class library_version_type {
-private:
+public:
     typedef uint_least16_t base_type;
+private:
     base_type t;
 public:
     library_version_type(): t(0) {}


### PR DESCRIPTION
Also allow to ignore extra parenthese error if BOOST_MPL_IGNORE_PARENTHESES_WARNING is set