### PR TITLE
Replace deprecated intrinsics: boostorg/type_traits/commit/a1d0b207c523c13b4fa46fd9b77bdb15ce554051

### DIFF
--- a/boost/type_traits/intrinsics.hpp
+++ b/boost/type_traits/intrinsics.hpp
@@ -183,25 +183,39 @@
 #   if (!defined(__GLIBCXX__) || (__GLIBCXX__ >= 20080306 && __GLIBCXX__ != 20080519)) && __has_feature(is_empty)
 #     define BOOST_IS_EMPTY(T) __is_empty(T)
 #   endif
-#   if __has_feature(has_trivial_constructor)
+#   if defined(__has_builtin) && __has_builtin(__is_trivially_constructible)
+#     define BOOST_HAS_TRIVIAL_CONSTRUCTOR(T) __is_trivially_constructible(T)
+#   elif __has_feature(has_trivial_constructor)
 #     define BOOST_HAS_TRIVIAL_CONSTRUCTOR(T) __has_trivial_constructor(T)
 #   endif
-#   if __has_feature(has_trivial_copy)
+#   if defined(__has_builtin) && __has_builtin(__is_trivially_copyable)
+#     define BOOST_HAS_TRIVIAL_COPY(T) (__is_trivially_copyable(T) && !is_reference<T>::value)
+#   elif __has_feature(has_trivial_copy)
 #     define BOOST_HAS_TRIVIAL_COPY(T) (__has_trivial_copy(T) && !is_reference<T>::value)
 #   endif
-#   if __has_feature(has_trivial_assign)
+#   if defined(__has_builtin) && __has_builtin(__is_trivially_assignable)
+#     define BOOST_HAS_TRIVIAL_ASSIGN(T) (__is_trivially_assignable(T&, const T&) && !is_volatile<T>::value && is_assignable<T&, const T&>::value)
+#   elif __has_feature(has_trivial_assign)
 #     define BOOST_HAS_TRIVIAL_ASSIGN(T) (__has_trivial_assign(T) && !is_volatile<T>::value && is_assignable<T&, const T&>::value)
 #   endif
-#   if __has_feature(has_trivial_destructor)
+#   if defined(__has_builtin) && __has_builtin(__is_trivially_destructible)
+#     define BOOST_HAS_TRIVIAL_DESTRUCTOR(T) (__is_trivially_destructible(T)  && is_destructible<T>::value)
+#   elif __has_feature(has_trivial_destructor)
 #     define BOOST_HAS_TRIVIAL_DESTRUCTOR(T) (__has_trivial_destructor(T)  && is_destructible<T>::value)
 #   endif
-#   if __has_feature(has_nothrow_constructor)
+#   if defined(__has_builtin) && __has_builtin(__is_nothrow_constructible)
+#     define BOOST_HAS_NOTHROW_CONSTRUCTOR(T) (__is_nothrow_constructible(T) && is_default_constructible<T>::value)
+#   elif __has_feature(has_nothrow_constructor)
 #     define BOOST_HAS_NOTHROW_CONSTRUCTOR(T) (__has_nothrow_constructor(T) && is_default_constructible<T>::value)
 #   endif
-#   if __has_feature(has_nothrow_copy)
+#   if defined(__has_builtin) && __has_builtin(__is_nothrow_constructible)
+#     define BOOST_HAS_NOTHROW_COPY(T) (__is_nothrow_constructible(T, const T&) && !is_volatile<T>::value && !is_reference<T>::value && is_copy_constructible<T>::value)
+#   elif __has_feature(has_nothrow_copy)
 #     define BOOST_HAS_NOTHROW_COPY(T) (__has_nothrow_copy(T) && !is_volatile<T>::value && !is_reference<T>::value && is_copy_constructible<T>::value)
 #   endif
-#   if __has_feature(has_nothrow_assign)
+#   if defined(__has_builtin) && __has_builtin(__is_nothrow_assignable)
+#     define BOOST_HAS_NOTHROW_ASSIGN(T) (__is_nothrow_assignable(T&, const T&) && !is_volatile<T>::value && is_assignable<T&, const T&>::value)
+#   elif __has_feature(has_nothrow_assign)
 #     define BOOST_HAS_NOTHROW_ASSIGN(T) (__has_nothrow_assign(T) && !is_volatile<T>::value && is_assignable<T&, const T&>::value)
 #   endif
 #   if __has_feature(has_virtual_destructor)


### PR DESCRIPTION
This should suppress the build warnings like [a]
[a]
```
boost/type_traits/has_nothrow_assign.hpp:65:7: warning: builtin __has_nothrow_assign is deprecated; use __is_nothrow_assignable instead [-Wdeprecated-builtins]
```